### PR TITLE
fix: put stripAnsi back into Options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ export declare const originalConsole: Console;
 
 type Options = {
   isSilent?: boolean;
+  stripAnsi?: boolean;
 };
 
 export enum ConsoleLevels {


### PR DESCRIPTION
It looks like this type was mistakenly removed here:
https://github.com/kevin940726/console-testing-library/commit/e5a039356e6fcbfd4cc0bb8f32a54960748c13a0#diff-7aa4473ede4abd9ec099e87fec67fd57afafaf39e05d493ab4533acc38547eb8L5